### PR TITLE
Force use of pyenv python bins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,12 @@ pyenv activate phantom
 pip install --upgrade pip
 ```
 
+Note: if the command `pyenv virtualenv 3.6.13 phantom` fails, try the following command instead:
+
+```bash
+pyenv install --patch 3.6.13 < <(curl -sSL https://github.com/python/cpython/commit/8ea6353.patch)
+```
+
 Use `source deactivate` to exit the virtual environment and `pyenv activate phantom` to reactivate it.
 
 #### Windows/Linux

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,16 @@ clean::
 	rm -f ../phcode42v2.tgz
 
 test::
-	pytest -vv
+	$$(pyenv which pytest) -vv
 
 validate::
-	python ./build-scripts/compile_app.pyc -c
+	$$(pyenv which python) ./build-scripts/compile_app.pyc -c
 
 style::
-	pre-commit run --all-files --show-diff-on-failure
+	$$(pyenv which pre-commit) run --all-files --show-diff-on-failure
 
 tar:: clean
-	python ./build-scripts/compile_app.pyc -t
+	$$(pyenv which python) ./build-scripts/compile_app.pyc -t
 
 deploy:: tar
 	scp ../phcode42v2.tgz "phantom@${PHANTOM_VM_IP_ADDR}":/home/phantom


### PR DESCRIPTION
* Force use pyenv specific binaries.
I am having issues with pyenv and the python binaries that are in my /usr/bin, this makes it always use the right binaries.
Also, I added a note in the contributing about an alternative way python 3.6.13 to install in case of troubles