### PR TITLE
Make password parameter of type string

### DIFF
--- a/code42.json
+++ b/code42.json
@@ -1425,7 +1425,7 @@
                 "password": {
                     "description":  "Password for newly created user",
                     "verbose": "Defaults to no password set, which leaves user in 'invited' state. They will need to reset password via email prior to first login.",
-                    "data_type": "password",
+                    "data_type": "string",
                     "required": false,
                     "primary": false,
                     "default": null,


### PR DESCRIPTION
The `create user` action doesn't work when we make the `password` parameter of data type `password`. The action fails without setting a message; you need to go into the debug logs to see the error. It appears to be a framework thing; I've posted about it on Phantom slack channel.