### PR TITLE
Adjust not found err message

### DIFF
--- a/code42_connector.py
+++ b/code42_connector.py
@@ -389,7 +389,9 @@ class Code42Connector(BaseConnector):
     def _get_user(self, username):
         users = self._client.users.get_by_username(username)["users"]
         if not users:
-            raise Exception(f"User '{username}' not found. Do you have the correct permissions?")
+            raise Exception(
+                f"User '{username}' not found. Do you have the correct permissions?"
+            )
         return users[0]
 
     def _get_user_id(self, username):

--- a/code42_connector.py
+++ b/code42_connector.py
@@ -361,7 +361,7 @@ class Code42Connector(BaseConnector):
     def _get_user(self, username):
         users = self._client.users.get_by_username(username)["users"]
         if not users:
-            raise Exception(f"User '{username}' does not exist")
+            raise Exception(f"User '{username}' not found. Do you have the correct permissions?")
         return users[0]
 
     def _get_user_id(self, username):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,15 @@ def mock_py42_client(mocker):
 @fixture
 def mock_py42_with_user(mocker, mock_py42_client):
     response_data = {"users": [{"userUid": TEST_USER_UID}]}
+    return _set_py42_users(mocker, mock_py42_client, response_data)
+
+
+@fixture
+def mock_py42_without_user(mocker, mock_py42_client):
+    return _set_py42_users(mocker, mock_py42_client, {"users": []})
+
+
+def _set_py42_users(mocker, mock_py42_client, response_data):
     mock_py42_client.users.get_by_username.return_value = create_mock_response(
         mocker, response_data
     )

--- a/tests/test_detectionlists_actions.py
+++ b/tests/test_detectionlists_actions.py
@@ -191,7 +191,6 @@ def _create_remove_hr_connector(client):
 def _create_list_hr_connector(client):
     connector = create_fake_connector("list_highrisk_employees")
     return attach_client(connector, client)
-    return _attach_client(connector, client)
 
 
 def _create_get_hr_connector(client):
@@ -215,6 +214,14 @@ def _attach_client(connector, client):
 
 
 class TestCode42DetectionListsConnector(object):
+    def test_handler_action_when_acting_on_user_that_does_not_exists_sets_expected_error_message(self):
+        param = {"username": "test@example.com"}
+        connector = _create_add_de_connector(mock_py42_with_user)
+        connector.handle_action(param)
+        mock_py42_with_user.detectionlists.departing_employee.add.assert_called_once_with(
+            "TEST_USER_UID"
+        )
+
     def test_handle_action_when_add_departing_employee_calls_add_with_expected_args(
         self, mock_py42_with_user
     ):

--- a/tests/test_detectionlists_actions.py
+++ b/tests/test_detectionlists_actions.py
@@ -9,6 +9,7 @@ from tests.conftest import (
     assert_successful_single_data,
     assert_successful_message,
     assert_successful_summary,
+    assert_fail_message,
     attach_client,
     TEST_USER_UID,
 )
@@ -205,13 +206,17 @@ def _attach_client(connector, client):
 
 
 class TestCode42DetectionListsConnector(object):
-    def test_handler_action_when_acting_on_user_that_does_not_exists_sets_expected_error_message(self):
+    def test_handler_action_when_acting_on_user_that_does_not_exists_sets_expected_error_message(
+        self, mock_py42_without_user
+    ):
         param = {"username": "test@example.com"}
-        connector = _create_add_de_connector(mock_py42_with_user)
+        connector = _create_add_de_connector(mock_py42_without_user)
         connector.handle_action(param)
-        mock_py42_with_user.detectionlists.departing_employee.add.assert_called_once_with(
-            "TEST_USER_UID"
+        expected_message = (
+            "Code42: Failed execution of action add_departing_employee: User 'test@example.com' not found. "
+            "Do you have the correct permissions?"
         )
+        assert_fail_message(connector, expected_message)
 
     def test_handle_action_when_add_departing_employee_calls_add_with_expected_args(
         self, mock_py42_with_user


### PR DESCRIPTION
Resolves some confusion from QA where detection lists actions are inconsistent with exceptions for a non-admin account.  List commands 403 as expected but other commands complain that the user does not exist... I explained how I can't force a 403 in this situation but I could adjust the error message to be less confusing.