### PR TITLE
Check whether matter ID is accessible before attempting to add/remove custodian

### DIFF
--- a/code42_connector.py
+++ b/code42_connector.py
@@ -419,6 +419,7 @@ class Code42Connector(BaseConnector):
         ]
         return memberships
 
+    # Fails when a legal hold matter is inaccessible from the user's account or the matter ID is not valid
     def _check_matter_is_accessible(self, matter_id):
         return self._client.legalhold.get_matter_by_uid(matter_id)
 

--- a/code42_connector.py
+++ b/code42_connector.py
@@ -336,6 +336,7 @@ class Code42Connector(BaseConnector):
         username = param["username"]
         matter_id = param["matter_id"]
         user_id = self._get_user_id(username)
+        self._check_matter_is_accessible(matter_id)
         response = self._client.legalhold.add_to_matter(user_id, matter_id)
         action_result.add_data(response.data)
         status_message = f"{username} was added to legal hold matter {matter_id}."
@@ -346,6 +347,7 @@ class Code42Connector(BaseConnector):
         username = param["username"]
         matter_id = param["matter_id"]
         user_id = self._get_user_id(username)
+        self._check_matter_is_accessible(matter_id)
         legal_hold_membership_id = self._get_legal_hold_membership_id(
             user_id, matter_id
         )
@@ -398,7 +400,7 @@ class Code42Connector(BaseConnector):
     def _get_user_id(self, username):
         return self._get_user(username)["userUid"]
 
-    # Following two helper functions are copy+pasted from cmds/legal_hold.py in `code42cli`
+    # Following three helper functions are copy+pasted from cmds/legal_hold.py in `code42cli`
     def _get_legal_hold_membership_id(self, user_id, matter_id):
         memberships = self._get_legal_hold_memberships_for_matter(matter_id)
         for member in memberships:
@@ -416,6 +418,9 @@ class Code42Connector(BaseConnector):
             for member in page["legalHoldMemberships"]
         ]
         return memberships
+
+    def _check_matter_is_accessible(self, matter_id):
+        return self._client.legalhold.get_matter_by_uid(matter_id)
 
 
 def main():

--- a/tests/test_legalhold_actions.py
+++ b/tests/test_legalhold_actions.py
@@ -112,6 +112,17 @@ class TestCode42LegalHoldConnector(object):
             f"test@example.com was added to legal hold matter {_TEST_MATTER_ID}.",
         )
 
+    def test_handle_action_when_add_legal_hold_custodian_checks_matter_is_accessible(
+        self, mock_py42_with_user
+    ):
+        param = {"username": "test@example.com", "matter_id": _TEST_MATTER_ID}
+        connector = _create_add_legalhold_custodian_connector(mock_py42_with_user)
+        connector.handle_action(param)
+        mock_py42_with_user.legalhold.get_matter_by_uid.assert_called_once_with(
+            _TEST_MATTER_ID
+        )
+        assert_success(connector)
+
     def test_handle_action_when_remove_legal_hold_custodian_calls_remove_with_expected_args(
         self, mock_py42_with_legal_hold_memberships
     ):
@@ -167,3 +178,16 @@ class TestCode42LegalHoldConnector(object):
             connector,
             f"Code42: User is not an active member of legal hold matter {_TEST_MATTER_ID} for action 'remove_legalhold_custodian'.",
         )
+
+    def test_handle_action_when_remove_legal_hold_custodian_checks_matter_is_accessible(
+        self, mock_py42_with_legal_hold_memberships
+    ):
+        param = {"username": "test@example.com", "matter_id": _TEST_MATTER_ID}
+        connector = _create_remove_legalhold_custodian_connector(
+            mock_py42_with_legal_hold_memberships
+        )
+        connector.handle_action(param)
+        mock_py42_with_legal_hold_memberships.legalhold.get_matter_by_uid.assert_called_once_with(
+            _TEST_MATTER_ID
+        )
+        assert_success(connector)


### PR DESCRIPTION
From Nikunj's testing of legal hold actions:
```
When I try to add legal hold custodian with invalid Matter Id it gives me below error :
Code42: Failed execution of action add_legalhold_custodian: Failure in HTTP call 403 Client Error: Forbidden for url: https://console.us.code42.com/api/LegalHoldMembership. Response content: [{"name":"SYSTEM","description":"Not authorized for this action"}]
```

This PR addresses the issue by checking whether the matter is accessible given current Py42 profile before adding or removing custodians on it.