### PR TITLE
mention ignoring params

### DIFF
--- a/code42.json
+++ b/code42.json
@@ -93,15 +93,13 @@
                     "allow_list": true
                 },
                 "start_time": {
-                    "description": "The start time to use in the initial poll in yyyy-MM-dd HH:MM:SS format (defaults to 30 days back)",
-                    "verbose": "Configure this parameter via the `start_date` configuration parameter on the asset.",
+                    "description": "Parameter ignored in this app",
                     "data_type": "string",
                     "required": false,
                     "order": 1
                 },
                 "end_time": {
-                    "description": "The end time to use in the initial poll in yyyy-MM-dd HH:MM:SS format (defaults to the current time)",
-                    "verbose": "Configure this parameter via the `end_date` configuration parameter on the asset.",
+                    "description": "Parameter ignored in this app",
                     "data_type": "string",
                     "required": false,
                     "order": 2


### PR DESCRIPTION
These params are actually the start and end time of the poll itself, and they get passed in automatically by the system.
Since we are not doing anything with them anymore, we are simply ignoring those params.
Other apps that ignore them mention that they are ignored in their summaries, so we should do the same.